### PR TITLE
Added BackoffTimeCheck utility (#269)

### DIFF
--- a/util/util_test.go
+++ b/util/util_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestEnsureBufBigEnough(t *testing.T) {
@@ -84,5 +85,91 @@ func TestCloseFile(t *testing.T) {
 	cferr = CloseFile(err, file)
 	if cferr == err {
 		t.Fatalf("Expected returned error to be different")
+	}
+}
+
+func TestBackoffTimeCheck(t *testing.T) {
+	// Check invalid values
+	if btc, err := NewBackoffTimeCheck(-1, 1, time.Second); btc != nil || err == nil {
+		t.Fatalf("NewBackoffTimeCheck returned: %v, %v", btc, err)
+	}
+	if btc, err := NewBackoffTimeCheck(0, 1, time.Second); btc != nil || err == nil {
+		t.Fatalf("NewBackoffTimeCheck returned: %v, %v", btc, err)
+	}
+	if btc, err := NewBackoffTimeCheck(time.Second, 0, time.Second); btc != nil || err == nil {
+		t.Fatalf("NewBackoffTimeCheck returned: %v, %v", btc, err)
+	}
+	if btc, err := NewBackoffTimeCheck(time.Second, -1, time.Second); btc != nil || err == nil {
+		t.Fatalf("NewBackoffTimeCheck returned: %v, %v", btc, err)
+	}
+	if btc, err := NewBackoffTimeCheck(time.Second, 1, -1); btc != nil || err == nil {
+		t.Fatalf("NewBackoffTimeCheck returned: %v, %v", btc, err)
+	}
+	if btc, err := NewBackoffTimeCheck(time.Second, 1, 0); btc != nil || err == nil {
+		t.Fatalf("NewBackoffTimeCheck returned: %v, %v", btc, err)
+	}
+	if btc, err := NewBackoffTimeCheck(time.Second, 1, time.Millisecond); btc != nil || err == nil {
+		t.Fatalf("NewBackoffTimeCheck returned: %v, %v", btc, err)
+	}
+
+	// Create a time check for printing.
+	print, _ := NewBackoffTimeCheck(20*time.Millisecond, 2, 100*time.Millisecond)
+	start := time.Now()
+	if !print.Ok() {
+		t.Fatal("Should have returned true")
+	}
+	if print.Ok() {
+		if elapsed := time.Since(start); elapsed < 20*time.Millisecond {
+			t.Fatalf("Should have returned false, only %v elapsed", elapsed)
+		}
+	}
+	start = time.Now()
+	time.Sleep(30 * time.Millisecond)
+	if !print.Ok() {
+		if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
+			t.Fatalf("Should have returned true, %v elapsed", elapsed)
+		}
+	}
+	// Now Reset and call, it should succeed
+	print.Reset()
+	if !print.Ok() {
+		t.Fatal("Should have returned true")
+	}
+	// Repeat calls until frequency is increased to the max
+	freqs := make([]time.Duration, 0)
+	last := time.Now()
+	timeout := time.Now().Add(350 * time.Millisecond)
+	for time.Now().Before(timeout) {
+		if print.Ok() {
+			freqs = append(freqs, time.Since(last))
+			last = time.Now()
+		}
+	}
+	// from the start, we should have printed, after the start at these times:
+	// 0:00:20ms, 0:00:40ms, 0:00:80ms, 0:00:100ms, 0:00:200ms
+	// but we max at 100, so expected values are:
+	expected := []int64{20, 40, 80, 100, 100}
+	if len(freqs) != 5 {
+		t.Fatalf("Expected ok 5 times, got %v", len(freqs))
+	}
+	for i, f := range freqs {
+		dur := time.Duration(expected[i] * int64(time.Millisecond))
+		if f < dur-5*time.Millisecond || f > dur+5*time.Millisecond {
+			t.Fatalf("Expected frequency to be +/- %v, got %v", dur, f)
+		}
+	}
+	// Now that we know that we have reached the max frequency,
+	// we are going to test the auto-reset. We need to wait that
+	// 2x the max frequency pass *after* the allowed next print,
+	// which at this point is 100ms ahead of us. So we need to
+	// sleep for at least 300ms. Sleep a bit more.
+	time.Sleep(350 * time.Millisecond)
+	// At this point, it is as if we were calling for the first time:
+	if !print.Ok() {
+		t.Fatal("Should have returned true")
+	}
+	// Check internals
+	if !print.nextTime.IsZero() {
+		t.Fatal("No auto-reset done")
 	}
 }


### PR DESCRIPTION
* Added BackoffTimeCheck utility

In situations where an error/trace is printed but there is a
possibility that the print is too frequent, which could cause the
log to quickly fill up, this utility should be used.

You first create a BackoffTimeCheck object giving a minimum and maximum
frequency and a factor at which the frequency is increased.

An Ok() function tells you if it is ok to issue the print statement.
When returning true, the object sets its next print target which
causes subsequent calls to Ok() to return false if they are made
too soon.

The frequency allowed to print is increased by the given factor
anytime the function returns Ok(). It is capped by the max frequency
set when creating the object.

After reaching the max frequency, if a call to Ok() is made after
more than 3x the max frequency since the last call that returned
true, then the call returns Ok() but is also auto-reset.

There is also a Reset() API to explicitly reset the object
to an initial state.